### PR TITLE
fix(insert): fix false positive on insertMany

### DIFF
--- a/src/lib/rules/check-insert-calls.js
+++ b/src/lib/rules/check-insert-calls.js
@@ -42,7 +42,7 @@ function eMQCheckInsertCalls(context) {
           ' to have at least 1 argument.');
         return false;
       }
-      if((!utils.nodeIsDynamic(args[0])) && !utils.nodeIsArray(args[0].type)) {
+      if((!utils.nodeIsDynamic(args[0])) && !utils.nodeIsArray(args[0])) {
         context.report(args[0], 'Expected ' + callSource +
           ' call first argument value to be an array.');
         return false;

--- a/src/lib/rules/check-insert-calls.mocha.js
+++ b/src/lib/rules/check-insert-calls.mocha.js
@@ -13,6 +13,8 @@ ruleTester.run('check-insert-calls', rule, {
     "mongoClient.db.collection('users').insertMany(gen(), {});",
     "mongoClient.db.collection('users').insertOne(ref, {});",
     "mongoClient.db.collection('users').insertMany(gen(), plop, kikoo);",
+    "mongoClient.db.collection('users').insertMany([{}], done);",
+    "mongoClient.db.collection('users').insertMany([{field: 'value'}], done);",
     "mongoClient.db.collection('users').insertOne(ref, plop, kikoo);",
     "mongoClient.db.collection('users').insertOne(ref, {}, function(){});",
   ],


### PR DESCRIPTION
This is now valid : 

``` js
mongoClient.db.collection('users').insertMany([{field: 'value'}], done);
```
